### PR TITLE
Pull the monasca-thresh jar directly from StackForge. No longer install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,5 +7,9 @@ kafka_metric:
   topic: metrics
   group: thresh-metric
 monasca_conf_dir: /etc/monasca
+monasca_jar_dir: /opt/monasca
 monasca_group: monasca
+thresh_group: thresh
 mysql_db: mon
+tarball_server: http://tarballs.openstack.org
+thresh_version: 1.0.0-SNAPSHOT

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,5 +11,5 @@ monasca_jar_dir: /opt/monasca
 monasca_group: monasca
 thresh_group: thresh
 mysql_db: mon
-tarball_server: http://tarballs.openstack.org
+tarball_base_url: http://tarballs.openstack.org/ci/monasca-thresh
 thresh_version: 1.0.0-SNAPSHOT

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,24 +1,32 @@
 ---
-- name: Install monasca-thresh
-  apt: name=monasca-thresh state=latest
-  notify:
-    - restart monasca-thresh
-
 - name: setup monasca_group
   group: name={{monasca_group}} system=yes
+
+- name: Setup user
+  user: name={{thresh_user}} system=yes group={{monasca_group}}
 
 - name: create conf_dir
   file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=775
 
-- name: Add thresh user to the monasca_group
-  user: name={{thresh_user}} append=yes groups={{monasca_group}}
+- name: create jar_dir
+  file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=755
+
+- name: Fetch thresh jar
+  get_url: dest={{monasca_jar_dir}}/monasca-thresh.jar url="{{tarball_server}}/ci/monasca-thresh/monasca-thresh-{{thresh_version}}-shaded.jar"
+  notify:
+    - restart monasca-thresh
 
 - name: create conf_file from template
   template: dest={{monasca_conf_dir}}/thresh-config.yml owner=root group={{monasca_group}} mode=640 src=thresh-config.yml.j2
   notify:
     - restart monasca-thresh
 
-- meta: flush_handlers
+- name: create service script from template
+  template: dest=/etc/init.d/monasca-thresh owner=root group=root mode=744 src=monasca-thresh.j2
+  notify:
+    - restart monasca-thresh
 
 - name: Enable the Service
   service: name=monasca-thresh state=started enabled=yes
+
+- meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=755
 
 - name: Fetch thresh jar
-  get_url: dest={{monasca_jar_dir}}/monasca-thresh.jar url="{{tarball_server}}/ci/monasca-thresh/monasca-thresh-{{thresh_version}}-shaded.jar"
+  get_url: dest={{monasca_jar_dir}}/monasca-thresh.jar url="{{tarball_base_url}}/monasca-thresh-{{thresh_version}}-shaded.jar"
   notify:
     - restart monasca-thresh
 

--- a/templates/monasca-thresh.j2
+++ b/templates/monasca-thresh.j2
@@ -1,0 +1,50 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          monasca-thresh
+# Required-Start:    $nimbus
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: Monitoring threshold engine running under storm
+# Description:
+### END INIT INFO
+
+case "$1" in
+    start)
+      $0 status
+      if [ $? -ne 0 ]; then
+        sudo -Hu {{thresh_user}} /opt/storm/current/bin/storm jar {{monasca_jar_dir}}/monasca-thresh.jar monasca.thresh.ThresholdingEngine {{monasca_conf_dir}}/thresh-config.yml thresh-cluster
+        exit $?
+      else
+        echo "monasca-thresh is already running"
+        exit 0
+      fi
+    ;;
+    stop)
+      # On system shutdown storm is being shutdown also and this will hang so skip shutting down thresh in that case
+      if [ -e '/sbin/runlevel' ]; then  # upstart/sysV case
+        if [ $(runlevel | cut -d\  -f 2) == 0 ]; then
+          exit 0
+        fi
+      else  # systemd case
+        systemctl list-units --type=target |grep shutdown.target
+        if [ $? -eq 0 ]; then
+          exit 0
+        fi
+      fi
+      sudo -Hu {{thresh_user}} /opt/storm/current/bin/storm kill thresh-cluster
+      # The above command returns but actually takes awhile loop watching status
+      while true; do
+        sudo -Hu {{thresh_user}} /opt/storm/current/bin/storm list |grep thresh-cluster
+        if [ $? -ne 0 ]; then break; fi
+        sleep 1
+      done
+    ;;
+    status)
+        sudo -Hu {{thresh_user}} /opt/storm/current/bin/storm list |grep thresh-cluster
+    ;;
+    restart)
+      $0 stop
+      $0 start
+    ;;
+esac


### PR DESCRIPTION
using a deb.

Creating the user and creating the control script is now done by this
role.
