### PR TITLE
Change to use a thresh specific base url because the other

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,5 +11,5 @@ monasca_jar_dir: /opt/monasca
 monasca_group: monasca
 thresh_group: thresh
 mysql_db: mon
-tarball_base_url: http://tarballs.openstack.org/ci/monasca-thresh
+thresh_tarball_base_url: http://tarballs.openstack.org/ci/monasca-thresh
 thresh_version: 1.0.0-SNAPSHOT

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=755
 
 - name: Fetch thresh jar
-  get_url: dest={{monasca_jar_dir}}/monasca-thresh.jar url="{{tarball_base_url}}/monasca-thresh-{{thresh_version}}-shaded.jar"
+  get_url: dest={{monasca_jar_dir}}/monasca-thresh.jar url="{{thresh_tarball_base_url}}/monasca-thresh-{{thresh_version}}-shaded.jar" force=yes
   notify:
     - restart monasca-thresh
 


### PR DESCRIPTION
components do that as well since it can't be shared

Set force=yes on the download of the jar so we always pick up the
new one
