### PR TITLE
Added configuration to whitelist and map metrics that are sent

### DIFF
--- a/templates/thresh-config.yml.j2
+++ b/templates/thresh-config.yml.j2
@@ -4,10 +4,48 @@ metricSpoutTasks: 2
 statsdConfig:
   host: "{{thresh_statsd_host}}"
   port: 8125
-  prefix: monasca.storm.
+  debugmetrics: false
   dimensions: !!map
     service : monitoring
     component : storm
+  whitelist: !!seq
+    - aggregation-bolt.execute-count.filtering-bolt_alarm-creation-stream
+    - aggregation-bolt.execute-count.filtering-bolt_default
+    - aggregation-bolt.execute-count.system_tick
+    - filtering-bolt.execute-count.event-bolt_metric-alarm-events
+    - filtering-bolt.execute-count.metrics-spout_default
+    - thresholding-bolt.execute-count.aggregation-bolt_default
+    - thresholding-bolt.execute-count.event-bolt_alarm-definition-events
+    - system.memory_heap.committedBytes
+    - system.memory_nonHeap.committedBytes
+    - system.newWorkerEvent
+    - system.startTimeSecs
+    - system.GC_ConcurrentMarkSweep.timeMs
+  metricmap: !!map
+    aggregation-bolt.execute-count.filtering-bolt_alarm-creation-stream :
+      monasca.storm.aggregation-bolt.execute-count.filtering-bolt_alarm-creation-stream
+    aggregation-bolt.execute-count.filtering-bolt_default :
+      monasca.storm.aggregation-bolt.execute-count.filtering-bolt_default
+    aggregation-bolt.execute-count.system_tick :
+      monasca.storm.aggregation-bolt.execute-count.system_tick
+    filtering-bolt.execute-count.event-bolt_metric-alarm-events :
+      monasca.storm.filtering-bolt.execute-count.event-bolt_metric-alarm-events
+    filtering-bolt.execute-count.metrics-spout_default :
+      monasca.storm.filtering-bolt.execute-count.metrics-spout_default
+    thresholding-bolt.execute-count.aggregation-bolt_default :
+      monasca.storm.thresholding-bolt.execute-count.aggregation-bolt_default
+    thresholding-bolt.execute-count.event-bolt_alarm-definition-events :
+      monasca.storm.thresholding-bolt.execute-count.event-bolt_alarm-definition-events
+    system.memory_heap.committedBytes :
+      monasca.storm.system.memory_heap.committedBytes
+    system.memory_nonHeap.committedBytes :
+      monasca.storm.system.memory_nonHeap.committedBytes
+    system.newWorkerEvent :
+      monasca.storm.system.newWorkerEvent
+    system.startTimeSecs :
+      monasca.storm.system.startTimeSecs
+    system.GC_ConcurrentMarkSweep.timeMs :
+      monasca.storm.system.GC_ConcurrentMarkSweep.timeMs
 
 
 metricSpoutConfig:

--- a/templates/thresh-config.yml.j2
+++ b/templates/thresh-config.yml.j2
@@ -23,29 +23,29 @@ statsdConfig:
     - system.GC_ConcurrentMarkSweep.timeMs
   metricmap: !!map
     aggregation-bolt.execute-count.filtering-bolt_alarm-creation-stream :
-      monasca.storm.aggregation-bolt.execute-count.filtering-bolt_alarm-creation-stream
+      monasca_threshold.aggregation-bolt.execute-count.filtering-bolt_alarm-creation-stream
     aggregation-bolt.execute-count.filtering-bolt_default :
-      monasca.storm.aggregation-bolt.execute-count.filtering-bolt_default
+      monasca_threshold.aggregation-bolt.execute-count.filtering-bolt_default
     aggregation-bolt.execute-count.system_tick :
-      monasca.storm.aggregation-bolt.execute-count.system_tick
+      monasca_threshold.aggregation-bolt.execute-count.system_tick
     filtering-bolt.execute-count.event-bolt_metric-alarm-events :
-      monasca.storm.filtering-bolt.execute-count.event-bolt_metric-alarm-events
+      monasca_threshold.filtering-bolt.execute-count.event-bolt_metric-alarm-events
     filtering-bolt.execute-count.metrics-spout_default :
-      monasca.storm.filtering-bolt.execute-count.metrics-spout_default
+      monasca_threshold.filtering-bolt.execute-count.metrics-spout_default
     thresholding-bolt.execute-count.aggregation-bolt_default :
-      monasca.storm.thresholding-bolt.execute-count.aggregation-bolt_default
+      monasca_threshold.thresholding-bolt.execute-count.aggregation-bolt_default
     thresholding-bolt.execute-count.event-bolt_alarm-definition-events :
-      monasca.storm.thresholding-bolt.execute-count.event-bolt_alarm-definition-events
+      monasca_threshold.thresholding-bolt.execute-count.event-bolt_alarm-definition-events
     system.memory_heap.committedBytes :
-      monasca.storm.system.memory_heap.committedBytes
+      monasca_threshold.system.memory_heap.committedBytes
     system.memory_nonHeap.committedBytes :
-      monasca.storm.system.memory_nonHeap.committedBytes
+      monasca_threshold.system.memory_nonHeap.committedBytes
     system.newWorkerEvent :
-      monasca.storm.system.newWorkerEvent
+      monasca_threshold.system.newWorkerEvent
     system.startTimeSecs :
-      monasca.storm.system.startTimeSecs
+      monasca_threshold.system.startTimeSecs
     system.GC_ConcurrentMarkSweep.timeMs :
-      monasca.storm.system.GC_ConcurrentMarkSweep.timeMs
+      monasca_threshold.system.GC_ConcurrentMarkSweep.timeMs
 
 
 metricSpoutConfig:


### PR DESCRIPTION
to StatsD through the Monasca Agent for monitoring Storm and
the Threshold Engine.

Related to:
  https://review.openstack.org/#/c/206266/
