### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,15 +8,15 @@
   user: name={{thresh_user}} system=yes group={{monasca_group}}
 
 - name: create conf_dir
-  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=775
+  file: path={{monasca_conf_dir}} state=directory owner=root group={{monasca_group}} mode=0775
 
 - name: create conf_file from template
-  template: dest={{ thresh_conf_file }} owner=root group={{monasca_group}} mode=640 src=thresh-config.yml.j2
+  template: dest={{ thresh_conf_file }} owner=root group={{monasca_group}} mode=0640 src=thresh-config.yml.j2
   notify:
     - restart monasca-thresh
 
 - name: create service script from template
-  template: dest=/etc/init.d/monasca-thresh owner=root group=root mode=744 src=monasca-thresh.j2
+  template: dest=/etc/init.d/monasca-thresh owner=root group=root mode=0744 src=monasca-thresh.j2
   notify:
     - restart monasca-thresh
 
@@ -29,7 +29,7 @@
   when: init.stdout != 'systemd'
 
 - name: create systemd config
-  template: dest=/etc/systemd/system/monasca-thresh.service owner=root group=root mode=644 src=monasca-thresh.service.j2
+  template: dest=/etc/systemd/system/monasca-thresh.service owner=root group=root mode=0644 src=monasca-thresh.service.j2
   notify:
     - restart monasca-thresh
   when: use_systemd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: create jar_dir
-  file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=755
+  file: path={{monasca_jar_dir}} state=directory owner=root group=root mode=0755
 
 - name: Fetch thresh jar
   get_url: dest={{monasca_jar_dir}}/monasca-thresh.jar url="{{thresh_tarball_base_url}}/monasca-thresh-{{thresh_version}}-shaded.jar" force=yes


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."
